### PR TITLE
feat: add WOD search filters with URL sync

### DIFF
--- a/webapp/components/WodSearch.vue
+++ b/webapp/components/WodSearch.vue
@@ -1,0 +1,161 @@
+<template>
+  <div class="space-y-4">
+    <div class="flex flex-col sm:flex-row gap-3">
+      <label class="input input-bordered flex items-center gap-2 flex-1">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          class="w-4 h-4 shrink-0 opacity-50"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z"
+            clip-rule="evenodd"
+          />
+        </svg>
+        <input v-model="searchQuery" type="text" class="grow" placeholder="Search movements, WOD type..." />
+        <button v-if="searchQuery" @click="searchQuery = ''" class="btn btn-xs btn-ghost" tabindex="-1">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="w-3 h-3">
+            <path
+              fill-rule="evenodd"
+              d="M4.22 4.22a.75.75 0 0 1 1.06 0L8 6.94l2.72-2.72a.75.75 0 1 1 1.06 1.06L9.06 8l2.72 2.72a.75.75 0 1 1-1.06 1.06L8 9.06l-2.72 2.72a.75.75 0 0 1-1.06-1.06L6.94 8 4.22 5.28a.75.75 0 0 1 0-1.06Z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </button>
+      </label>
+
+      <select v-model="selectedType" class="select select-bordered w-full sm:w-48">
+        <option value="">All types</option>
+        <option v-for="type in WOD_TYPES" :key="type" :value="type">{{ type }}</option>
+      </select>
+
+      <div class="dropdown dropdown-end">
+        <button class="btn btn-outline btn-soft w-full sm:w-auto">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4 shrink-0">
+            <path
+              fill-rule="evenodd"
+              d="M2 3.75A.75.75 0 0 1 2.75 3h10.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 3.75ZM2 8a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 8Zm6 4.25a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75Z"
+              clip-rule="evenodd"
+            />
+          </svg>
+          Movements
+          <span v-if="selectedMovements.length" class="badge badge-sm">{{ selectedMovements.length }}</span>
+        </button>
+        <div
+          class="dropdown-content card card-sm bg-base-100 shadow-lg z-10 max-h-72 overflow-y-auto w-64 border border-base-200 mt-1"
+        >
+          <div class="card-body p-3">
+            <label
+              v-for="movement in MOVEMENT_LIST"
+              :key="movement"
+              class="flex items-center gap-2 py-1 px-1 cursor-pointer hover:bg-base-200 rounded"
+            >
+              <input
+                type="checkbox"
+                :checked="selectedMovements.includes(movement)"
+                @change="toggleMovement(movement)"
+                class="checkbox checkbox-xs"
+              />
+              <span class="text-sm">{{ movement }}</span>
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="hasActiveFilters" class="flex flex-wrap gap-2 items-center">
+      <span class="text-xs text-base-content/60">Filters:</span>
+      <span
+        v-for="movement in selectedMovements"
+        :key="movement"
+        class="badge badge-soft gap-1 cursor-pointer hover:badge-error transition-colors"
+        @click="toggleMovement(movement)"
+      >
+        {{ movement }}
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="w-3 h-3">
+          <path
+            fill-rule="evenodd"
+            d="M4.22 4.22a.75.75 0 0 1 1.06 0L8 6.94l2.72-2.72a.75.75 0 1 1 1.06 1.06L9.06 8l2.72 2.72a.75.75 0 1 1-1.06 1.06L8 9.06l-2.72 2.72a.75.75 0 0 1-1.06-1.06L6.94 8 4.22 5.28a.75.75 0 0 1 0-1.06Z"
+            clip-rule="evenodd"
+          />
+        </svg>
+      </span>
+      <span
+        v-if="selectedType"
+        class="badge badge-soft gap-1 cursor-pointer hover:badge-error transition-colors"
+        @click="selectedType = ''"
+      >
+        {{ selectedType }}
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="w-3 h-3">
+          <path
+            fill-rule="evenodd"
+            d="M4.22 4.22a.75.75 0 0 1 1.06 0L8 6.94l2.72-2.72a.75.75 0 1 1 1.06 1.06L9.06 8l2.72 2.72a.75.75 0 1 1-1.06 1.06L8 9.06l-2.72 2.72a.75.75 0 0 1-1.06-1.06L6.94 8 4.22 5.28a.75.75 0 0 1 0-1.06Z"
+            clip-rule="evenodd"
+          />
+        </svg>
+      </span>
+      <button @click="clearAll" class="btn btn-ghost btn-xs text-primary">Clear all</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const searchQuery = defineModel<string>('searchQuery', { default: '' });
+const selectedType = defineModel<string>('selectedType', { default: '' });
+const selectedMovements = defineModel<string[]>('selectedMovements', { default: [] });
+
+const WOD_TYPES = ['AMRAP', 'For Time', 'EMOM', 'E2MOM', 'RFT', 'NFT', 'Tabata'] as const;
+
+const MOVEMENT_LIST = [
+  'Bear Crawl',
+  'Bench Press',
+  'Bike',
+  'Box Jump',
+  'Burpee',
+  'Chest to Bar',
+  'Clean',
+  'Deadlift',
+  'Double Under',
+  'Dumbbell Snatch',
+  'Handstand Push-up',
+  'Handstand Walk',
+  'Jerk',
+  'Kettlebell Swing',
+  'Lunge',
+  'Muscle-up',
+  'Overhead Press',
+  'Pistol',
+  'Pull-up',
+  'Push-up',
+  'Rope Climb',
+  'Row',
+  'Run',
+  'Snatch',
+  'Squat',
+  'Thruster',
+  'Toes to Bar',
+  'Turkish Get-up',
+  'Wall Ball',
+] as const;
+
+const hasActiveFilters = computed(
+  () => searchQuery.value !== '' || selectedType.value !== '' || selectedMovements.value.length > 0,
+);
+
+function toggleMovement(movement: string) {
+  const idx = selectedMovements.value.indexOf(movement);
+  if (idx !== -1) {
+    selectedMovements.value = selectedMovements.value.filter((m: string) => m !== movement);
+  } else {
+    selectedMovements.value = [...selectedMovements.value, movement];
+  }
+}
+
+function clearAll() {
+  searchQuery.value = '';
+  selectedType.value = '';
+  selectedMovements.value = [];
+}
+</script>

--- a/webapp/pages/index.vue
+++ b/webapp/pages/index.vue
@@ -1,32 +1,176 @@
 <template>
   <div class="min-h-screen bg-base-200">
-    <!-- HERO -->
-    <section class="py-20 text-center">
-      <div class="max-w-4xl mx-auto">
-        <h1 class="text-5xl font-extrabold text-primary">🏋 CompTrain WOD History</h1>
-        <p class="mt-4 text-xl text-gray-500">Explore and relive the toughest workouts from past sessions.</p>
+    <section class="py-16 sm:py-20 text-center">
+      <div class="max-w-4xl mx-auto px-4">
+        <h1 class="text-4xl sm:text-5xl font-extrabold text-primary">CompTrain WOD History</h1>
+        <p class="mt-4 text-lg sm:text-xl text-base-content/60">
+          Explore and relive the toughest workouts from past sessions.
+        </p>
       </div>
     </section>
 
-    <!-- WODS GRID -->
-    <section class="px-4 pb-20">
-      <div class="max-w-7xl mx-auto grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+    <section class="px-4 pb-20 max-w-7xl mx-auto space-y-6">
+      <WodSearch
+        v-model:search-query="searchQuery"
+        v-model:selected-type="selectedType"
+        v-model:selected-movements="selectedMovements"
+      />
+
+      <p class="text-sm text-base-content/50">
+        {{ filteredWorkouts.length }} result{{ filteredWorkouts.length !== 1 ? 's' : '' }}
+        <span v-if="hasActiveFilters">(filtered)</span>
+      </p>
+
+      <div v-if="filteredWorkouts.length" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         <div
-          v-for="(wod, index) in workouts"
-          :key="index"
-          class="card shadow-xl hover:shadow-2xl transition duration-300 bg-white border border-base-300"
+          v-for="(wod, index) in filteredWorkouts"
+          :key="wod.id || index"
+          class="card shadow-sm hover:shadow-md transition-shadow duration-300 bg-white border border-base-300"
         >
           <div class="card-body">
-            <h2 class="card-title text-primary-content text-xl font-bold">{{ wod.title }}</h2>
-            <p class="whitespace-pre-wrap text-gray-700">{{ wod.content }}</p>
+            <h2 class="card-title text-xl font-bold">{{ wod.title }}</h2>
+            <p class="whitespace-pre-wrap text-base-content/70 text-sm leading-relaxed">{{ wod.content }}</p>
           </div>
         </div>
+      </div>
+
+      <div
+        v-else
+        class="text-center py-20 text-base-content/40"
+      >
+        <p class="text-lg">No WODs match your search criteria.</p>
+        <button @click="clearFilters" class="btn btn-primary btn-sm mt-4">
+          Reset filters
+        </button>
       </div>
     </section>
   </div>
 </template>
 
 <script setup lang="ts">
+declare global {
+  interface Window {
+    plausible?: (event: string, options?: { props?: Record<string, string> }) => void
+  }
+}
+
+interface Workout {
+  id: number
+  createdAt: string
+  updatedAt: string
+  title: string
+  content: string | null
+}
+
+interface EnrichedWorkout extends Workout {
+  parsedTypes: string[]
+  parsedMovements: string[]
+}
+
 const config = useRuntimeConfig()
-const { data: workouts } = await useFetch(`${config.public.API_URL}/workouts`)
+const { data: workouts } = await useFetch<Workout[]>(`${config.public.API_URL}/workouts`)
+
+const route = useRoute()
+const router = useRouter()
+
+const searchQuery = ref('')
+const selectedType = ref('')
+const selectedMovements = ref<string[]>([])
+
+onMounted(() => {
+  if (route.query.q) searchQuery.value = route.query.q as string
+  if (route.query.type) selectedType.value = route.query.type as string
+  if (route.query.movements) {
+    selectedMovements.value = (route.query.movements as string).split(',').filter(Boolean)
+  }
+})
+
+const WOD_TYPE_PATTERNS: { label: string; patterns: string[] }[] = [
+  { label: 'AMRAP', patterns: ['AMRAP', 'As Many Rounds As Possible'] },
+  { label: 'For Time', patterns: ['for time'] },
+  { label: 'EMOM', patterns: ['EMOM', 'Every Minute On the Minute'] },
+  { label: 'E2MOM', patterns: ['E2MOM', 'Every 2 Minutes'] },
+  { label: 'RFT', patterns: ['RFT', 'Rounds For Time', 'rounds for time'] },
+  { label: 'NFT', patterns: ['NFT', 'Not For Time'] },
+  { label: 'Tabata', patterns: ['Tabata'] },
+]
+
+const MOVEMENTS = [
+  'Thruster', 'Pull-up', 'Deadlift', 'Box Jump', 'Double Under',
+  'Clean', 'Jerk', 'Snatch', 'Burpee', 'Push-up',
+  'Toes to Bar', 'Wall Ball', 'Row', 'Run', 'Bike',
+  'Rope Climb', 'Handstand Push-up', 'Muscle-up', 'Kettlebell Swing', 'Lunge',
+  'Squat', 'Bench Press', 'Overhead Press', 'Pistol',
+  'Bar Muscle-up', 'Ring Muscle-up', 'Chest to Bar', 'Turkish Get-up',
+  'Bear Crawl', 'Handstand Walk', 'Dumbbell Snatch',
+]
+
+function parseWodType(content: string): string[] {
+  if (!content) return []
+  const lower = content.toLowerCase()
+  return WOD_TYPE_PATTERNS
+    .filter(({ patterns }) => patterns.some(p => lower.includes(p.toLowerCase())))
+    .map(({ label }) => label)
+}
+
+function parseMovements(content: string): string[] {
+  if (!content) return []
+  const lower = content.toLowerCase()
+  return MOVEMENTS.filter(m => lower.includes(m.toLowerCase()))
+}
+
+const enrichedWorkouts = computed<EnrichedWorkout[]>(() =>
+  (workouts.value || []).map(wod => ({
+    ...wod,
+    parsedTypes: parseWodType(wod.content || ''),
+    parsedMovements: parseMovements(wod.content || ''),
+  }))
+)
+
+const hasActiveFilters = computed(() =>
+  searchQuery.value !== '' || selectedType.value !== '' || selectedMovements.value.length > 0
+)
+
+const filteredWorkouts = computed<EnrichedWorkout[]>(() =>
+  enrichedWorkouts.value.filter(wod => {
+    if (searchQuery.value) {
+      const q = searchQuery.value.toLowerCase()
+      if (!wod.title.toLowerCase().includes(q) && !(wod.content || '').toLowerCase().includes(q)) {
+        return false
+      }
+    }
+    if (selectedType.value && !wod.parsedTypes.includes(selectedType.value)) {
+      return false
+    }
+    if (selectedMovements.value.length) {
+      if (!selectedMovements.value.every(m => wod.parsedMovements.includes(m))) {
+        return false
+      }
+    }
+    return true
+  })
+)
+
+watch([searchQuery, selectedType, selectedMovements], () => {
+  const query: Record<string, string> = {}
+  if (searchQuery.value) query.q = searchQuery.value
+  if (selectedType.value) query.type = selectedType.value
+  if (selectedMovements.value.length) query.movements = selectedMovements.value.join(',')
+  router.replace({ query })
+
+  if (typeof window === 'undefined' || !window.plausible) return
+  window.plausible('filter', {
+    props: {
+      search: searchQuery.value || '(none)',
+      type: selectedType.value || '(none)',
+      movements: selectedMovements.value.length ? selectedMovements.value.join(', ') : '(none)',
+    },
+  })
+})
+
+function clearFilters() {
+  searchQuery.value = ''
+  selectedType.value = ''
+  selectedMovements.value = []
+}
 </script>


### PR DESCRIPTION
## Summary

- **Search bar** with text search, WOD type dropdown, and movement multi-select
- **URL sync** — filters are persisted in query params (`?q=`, `?type=`, `?movements=`) via `router.replace`
- **Plausible events** — custom `filter` event sent on every filter change with search, type, and movements as props
- **Empty state** — "No WODs match" message with reset button
- **Badges actifs** — active filters shown as removable badges

## Files changed
- `webapp/components/WodSearch.vue` — new filter UI component
- `webapp/pages/index.vue` — filtering logic, URL sync, Plausible integration