### PR TITLE
fix(webapp): report one search event per word instead of per keystroke

### DIFF
--- a/webapp/composables/useDebounce.ts
+++ b/webapp/composables/useDebounce.ts
@@ -1,0 +1,19 @@
+import { ref, watch, onUnmounted, readonly, type Ref } from 'vue'
+
+export function useDebounce<T>(source: Ref<T>, delay: number = 300): Readonly<Ref<T>> {
+  const debounced = ref(source.value) as Ref<T>
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  watch(source, () => {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      debounced.value = source.value
+    }, delay)
+  })
+
+  onUnmounted(() => {
+    if (timer) clearTimeout(timer)
+  })
+
+  return readonly(debounced)
+}

--- a/webapp/pages/index.vue
+++ b/webapp/pages/index.vue
@@ -69,8 +69,13 @@ const route = useRoute();
 const router = useRouter();
 
 const searchQuery = ref('');
+const debouncedSearchQuery = useDebounce(searchQuery, 500);
 const selectedType = ref('');
 const selectedMovements = ref<string[]>([]);
+
+// ponytail: dedupe key doubles as the hydration guard — filters restored from the
+// URL are pre-seeded as "already sent", so a shared link reports no search.
+let lastSentFilterKey = '';
 
 onMounted(() => {
   if (route.query.q) searchQuery.value = route.query.q as string;
@@ -78,6 +83,9 @@ onMounted(() => {
   if (route.query.movements) {
     selectedMovements.value = (route.query.movements as string).split(',').filter(Boolean);
   }
+  // Seed from the live value: the debounced ref still holds its setup-time '' here,
+  // but it will settle on searchQuery 500ms from now — that is the key to pre-empt.
+  lastSentFilterKey = JSON.stringify(buildFilterProps(searchQuery.value));
 });
 
 const WOD_TYPE_PATTERNS: { label: string; patterns: string[] }[] = [
@@ -150,6 +158,14 @@ const hasActiveFilters = computed(
   () => searchQuery.value !== '' || selectedType.value !== '' || selectedMovements.value.length > 0,
 );
 
+function buildFilterProps(search: string) {
+  return {
+    search: search || '(none)',
+    type: selectedType.value || '(none)',
+    movements: selectedMovements.value.length ? selectedMovements.value.join(', ') : '(none)',
+  };
+}
+
 const filteredWorkouts = computed<EnrichedWorkout[]>(() =>
   enrichedWorkouts.value.filter((wod) => {
     if (searchQuery.value) {
@@ -170,22 +186,26 @@ const filteredWorkouts = computed<EnrichedWorkout[]>(() =>
   }),
 );
 
+// URL stays instant so a link copied mid-typing carries the full query.
 watch([searchQuery, selectedType, selectedMovements], () => {
   const query: Record<string, string> = {};
   if (searchQuery.value) query.q = searchQuery.value;
   if (selectedType.value) query.type = selectedType.value;
   if (selectedMovements.value.length) query.movements = selectedMovements.value.join(',');
   router.replace({ query });
+});
 
+// Analytics waits for the debounced text: one event per finished word, not per keystroke.
+watch([debouncedSearchQuery, selectedType, selectedMovements], () => {
   if (!hasActiveFilters.value) return;
   if (typeof window === 'undefined' || !window.plausible) return;
-  window.plausible('filter', {
-    props: {
-      search: searchQuery.value || '(none)',
-      type: selectedType.value || '(none)',
-      movements: selectedMovements.value.length ? selectedMovements.value.join(', ') : '(none)',
-    },
-  });
+
+  const props = buildFilterProps(debouncedSearchQuery.value);
+  const key = JSON.stringify(props);
+  if (key === lastSentFilterKey) return;
+  lastSentFilterKey = key;
+
+  window.plausible('filter', { props });
 });
 
 function clearFilters() {


### PR DESCRIPTION
## Description

The Plausible `filter` event fired on every keystroke in the search box, so typing "thruster" recorded eight searches. Prefixes like `t`, `th` and `thr` drowned out the real queries, and the event count no longer bore any relation to how many searches users actually ran.

While fixing that, a second defect surfaced feeding the same metric: restoring filters from the URL on mount also emitted an event. Every visit to a shared link such as `?q=thruster&type=AMRAP` was counted as a search nobody typed, inflating the stats silently.

## Changes

- **One event per finished word.** The analytics event now waits for the search text to settle for 500ms.
- **No phantom event on hydration.** The dedupe key is seeded during `onMounted` from the value the debounce will settle on, so filters restored from the URL report nothing.
- **URL sync stays instant.** The single watcher is split in two: the URL follows every keystroke so a link copied mid-typing carries the full query, and only the analytics event is delayed.
- **No duplicates.** Deduplicating on the emitted props also drops repeats from reselecting the same type or retyping an identical word.
- New `useDebounce` composable, committed separately.

Trade-offs and alternatives considered:

- **Local `useDebounce` over `@vueuse/core`**: the dependency is not installed and there is no Nuxt module for it, so adding one for a 19-line helper would be a larger change than the helper.
- **Debounce over blur/Enter**: firing on blur is closer to a literal "finished word", but misses users who type and then scroll the results without ever blurring — common on mobile.
- **Filter clicks stay immediate and are deliberately not grouped**: a click is one deliberate action, unlike a character in a word. Clicking a type then a movement in quick succession emits two events, which is intended.

A slow typist pausing over 500ms mid-word will still emit two events (`"box"`, then `"box jump"`). That is inherent to any debounce and is the cost of not requiring blur/Enter.

## Testing

`npm run build` passes.

No test runner is configured in `webapp/package.json`, so the analytics logic was verified with a standalone script replaying the debounce and dedupe interaction across seven cases: one event per word, slow typing, no event on hydration from a shared link, a real edit after hydration, immediate clicks, no event when filters are cleared, and no duplicate on repeated selections. That check caught a defect in the first version of the hydration seed, where the debounced ref still held its setup-time empty value and the event leaked through 500ms later.

Not verified in a browser. To confirm manually: `npm run dev`, then `window.plausible = (...a) => console.log(...a)` in the console, since the Plausible script is only injected when the `ANALYTICS_*` env variables are set.